### PR TITLE
添加相关测试

### DIFF
--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/expansion/BaseCapacityExpansionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/expansion/BaseCapacityExpansionIT.java
@@ -132,6 +132,8 @@ public abstract class BaseCapacityExpansionIT {
     queryNewData();
     // 再次写入并查询所有新数据
     testWriteAndQueryNewDataAfterCE();
+    // 测试插入和dummy路径相同的数据
+    testWriteAndQueryWithSameDummyPathInExp();
   }
 
   @Test
@@ -166,6 +168,8 @@ public abstract class BaseCapacityExpansionIT {
     testWriteAndQueryNewDataAfterCE();
     // 测试带前缀的添加和移除存储引擎操作
     testAddAndRemoveStorageEngineWithPrefix();
+    // 测试插入和dummy路径相同的数据
+    testWriteAndQueryWithSameDummyPathInExp();
   }
 
   @Test
@@ -290,10 +294,27 @@ public abstract class BaseCapacityExpansionIT {
     SQLTestTools.executeAndCompare(session, statement, expect);
   }
 
+  private void testWriteAndQueryWithSameDummyPathInExp() {
+    try {
+      // 插入和扩容路径相同的数据
+      session.executeSql("insert into nt.wf04.wt01 (key, temperature) values (1600, 123.123);");
+      String statement = "select temperature from nt.wf04.wt01";
+      List<String> pathList = Collections.singletonList("nt.wf04.wt01.temperature");
+      List<List<Object>> valuesList = expValuesList2;
+      valuesList.add(Collections.singletonList(123.123));
+      SQLTestTools.executeAndCompare(session, statement, pathList, valuesList);
+    } catch (ExecutionException | SessionException e) {
+      logger.error("insert new data after capacity expansion error: {}", e.getMessage());
+    }
+  }
+
   private void testWriteAndQueryNewDataAfterCE() {
     try {
       session.executeSql("insert into ln.wf02 (key, version) values (1600, \"v48\");");
       queryAllNewData();
+      // 插入和扩容路径相同的数据，再次查询
+      session.executeSql("insert into mn.wf01.wt01 (key, temperature) values (1600, 123.123);");
+
     } catch (ExecutionException | SessionException e) {
       logger.error("insert new data after capacity expansion error: {}", e.getMessage());
     }

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/expansion/BaseCapacityExpansionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/expansion/BaseCapacityExpansionIT.java
@@ -300,7 +300,7 @@ public abstract class BaseCapacityExpansionIT {
       session.executeSql("insert into nt.wf04.wt01 (key, temperature) values (1600, 123.123);");
       String statement = "select temperature from nt.wf04.wt01";
       List<String> pathList = Collections.singletonList("nt.wf04.wt01.temperature");
-      List<List<Object>> valuesList = expValuesList2;
+      List<List<Object>> valuesList = new ArrayList<>(expValuesList2);
       valuesList.add(Collections.singletonList(123.123));
       SQLTestTools.executeAndCompare(session, statement, pathList, valuesList);
     } catch (ExecutionException | SessionException e) {


### PR DESCRIPTION
需要等对文件系统的测试改为double类型的测试，也就是不测binary后才能进行此pr。因为如果要测dummy的数据和normal数据，key不一样，但序列一样，一个是Binary类型，一个是double类型，不能查出来